### PR TITLE
feat: Add aiohttp test project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,4 +166,5 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
-
+.claude/settings.local.json
+.serena

--- a/test-aiohttp/main.py
+++ b/test-aiohttp/main.py
@@ -6,7 +6,7 @@ from sentry_sdk.integrations.aiohttp import AioHttpIntegration
 
 
 sentry_sdk.init(
-    dsn="",
+    dsn=os.environ.get("SENTRY_DSN"),
     environment=os.environ.get("ENV", "test"),
     _experiments={"trace_lifecycle": "stream"},
     traces_sample_rate=1.0,

--- a/test-aiohttp/main.py
+++ b/test-aiohttp/main.py
@@ -1,0 +1,55 @@
+import os
+
+import sentry_sdk
+from aiohttp import web
+from sentry_sdk.integrations.aiohttp import AioHttpIntegration
+
+
+sentry_sdk.init(
+    dsn="",
+    environment=os.environ.get("ENV", "test"),
+    _experiments={"trace_lifecycle": "stream"},
+    traces_sample_rate=1.0,
+    profiles_sample_rate=1.0,
+    debug=True,
+    integrations=[
+        AioHttpIntegration(),
+    ],
+)
+
+
+async def index(request):
+    return web.json_response(
+        {
+            "hello": "world!",
+            "error": "http://localhost:5000/error",
+            "http-error": "http://localhost:5000/http-error",
+        }
+    )
+
+
+async def error(request):
+    sentry_sdk.set_user({"id": "testuser"})
+    raise ValueError("help! an error!")
+
+
+async def http_error(request):
+    raise web.HTTPInternalServerError(reason="something went wrong")
+
+
+@web.middleware
+async def test_middleware(request, handler):
+    print("middleware")
+    return await handler(request)
+
+
+def make_app():
+    app = web.Application(middlewares=[test_middleware])
+    app.router.add_get("/", index)
+    app.router.add_get("/error", error)
+    app.router.add_get("/http-error", http_error)
+    return app
+
+
+if __name__ == "__main__":
+    web.run_app(make_app(), port=5000)

--- a/test-aiohttp/pyproject.toml
+++ b/test-aiohttp/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "test-aiohttp"
+version = "0"
+requires-python = ">=3.12"
+
+dependencies = [
+    "aiohttp>=3.9",
+    "ipdb>=0.13.13",
+    "sentry-sdk[aiohttp]",
+]
+
+[tool.uv.sources]
+sentry-sdk = { path = "../../sentry-python", editable = true }

--- a/test-aiohttp/run.sh
+++ b/test-aiohttp/run.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# exit on first error
+set -euo pipefail
+
+# Install uv if it's not installed
+if ! command -v uv &> /dev/null; then
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
+
+# Run the script
+uv run python main.py


### PR DESCRIPTION
Add a minimal aiohttp app wired up to the local sentry-python SDK with the AioHttpIntegration enabled.

The app exposes three routes used to exercise the integration end-to-end against a local SDK build:
- `/` returns a JSON index pointing at the other routes
- `/error` raises an unhandled `ValueError` after setting a user, to verify error capture and user scoping
- `/http-error` raises `web.HTTPInternalServerError` to verify how aiohttp HTTP-level errors flow through

A no-op middleware is registered to confirm middleware ordering with the integration. `pyproject.toml` pins `sentry-sdk` to the sibling `../../sentry-python` checkout via `[tool.uv.sources]` so the sample runs against in-progress SDK changes, and `run.sh` bootstraps `uv` if missing and starts the server on port 5000.

`.gitignore` is also extended to skip `.claude/settings.local.json` and `.serena` so local agent tooling files don't leak into commits.