### PR TITLE
build(test-checkin-in-trace-id): Migrate to uv and pyproject.toml

### DIFF
--- a/test-checkin-in-trace-id/pyproject.toml
+++ b/test-checkin-in-trace-id/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "test-checkin-in-trace-id"
+version = "0"
+requires-python = ">=3.12"
+
+dependencies = [
+    "celery[redis]>=5.4.0",
+    "ipdb>=0.13.13",
+    "requests>=2.32.3",
+    "sentry-sdk[celery]",
+]
+
+[tool.uv.sources]
+sentry-sdk = { path = "../../sentry-python", editable = true }

--- a/test-checkin-in-trace-id/requirements.txt
+++ b/test-checkin-in-trace-id/requirements.txt
@@ -1,7 +1,0 @@
-ipdb
-
-requests
-
-celery[redis]
-
--e ../../../code/sentry-python

--- a/test-checkin-in-trace-id/run-celery.sh
+++ b/test-checkin-in-trace-id/run-celery.sh
@@ -5,6 +5,13 @@ if ! command -v uv &> /dev/null; then
     curl -LsSf https://astral.sh/uv/install.sh | sh
 fi
 
+if [ ! -d ".venv" ]; then
+    uv venv
+fi
+
+source .venv/bin/activate
+uv pip install -e .
+
 redis-server &
 
-uv run celery -A tasks worker --loglevel=DEBUG
+celery -A tasks worker --loglevel=DEBUG

--- a/test-checkin-in-trace-id/run-celery.sh
+++ b/test-checkin-in-trace-id/run-celery.sh
@@ -5,13 +5,6 @@ if ! command -v uv &> /dev/null; then
     curl -LsSf https://astral.sh/uv/install.sh | sh
 fi
 
-if [ ! -d ".venv" ]; then
-    uv venv
-fi
-
-source .venv/bin/activate
-uv pip install -e .
-
 redis-server &
 
-celery -A tasks worker --loglevel=DEBUG
+uv run celery -A tasks worker --loglevel=DEBUG

--- a/test-checkin-in-trace-id/run-celery.sh
+++ b/test-checkin-in-trace-id/run-celery.sh
@@ -1,9 +1,10 @@
-python -m venv .venv
+#!/usr/bin/env bash
+set -euo pipefail
 
-source .venv/bin/activate
-
-pip install -r requirements.txt
+if ! command -v uv &> /dev/null; then
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
 
 redis-server &
 
-celery -A tasks worker --loglevel=DEBUG
+uv run celery -A tasks worker --loglevel=DEBUG

--- a/test-checkin-in-trace-id/run.sh
+++ b/test-checkin-in-trace-id/run.sh
@@ -5,11 +5,4 @@ if ! command -v uv &> /dev/null; then
     curl -LsSf https://astral.sh/uv/install.sh | sh
 fi
 
-if [ ! -d ".venv" ]; then
-    uv venv
-fi
-
-source .venv/bin/activate
-uv pip install -e .
-
-python main.py
+uv run python main.py

--- a/test-checkin-in-trace-id/run.sh
+++ b/test-checkin-in-trace-id/run.sh
@@ -5,4 +5,11 @@ if ! command -v uv &> /dev/null; then
     curl -LsSf https://astral.sh/uv/install.sh | sh
 fi
 
-uv run python main.py
+if [ ! -d ".venv" ]; then
+    uv venv
+fi
+
+source .venv/bin/activate
+uv pip install -e .
+
+python main.py

--- a/test-checkin-in-trace-id/run.sh
+++ b/test-checkin-in-trace-id/run.sh
@@ -1,8 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
 
-python -m venv .venv
+if ! command -v uv &> /dev/null; then
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
 
-source .venv/bin/activate
-
-pip install -r requirements.txt
-
-python main.py
+uv run python main.py


### PR DESCRIPTION
## Summary
- Replace `pip`/`requirements.txt` with `uv`/`pyproject.toml` for dependency management
- Update `run.sh` and `run-celery.sh` to use `uv run` instead of manual venv creation and pip install
- Remove legacy `requirements.txt`

Refs PY-2437

## Test plan
- [ ] Verify `pyproject.toml` includes all dependencies from the original `requirements.txt`
- [ ] Verify `run.sh` and `run-celery.sh` use `uv run`
- [ ] Verify `requirements.txt` is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)