### PR TITLE
feat: Add Pyramid test project

### DIFF
--- a/test-pyramid/main.py
+++ b/test-pyramid/main.py
@@ -1,0 +1,50 @@
+import os
+
+import sentry_sdk
+from pyramid.config import Configurator
+from pyramid.response import Response
+from waitress import serve
+
+sentry_sdk.init(
+    dsn=os.environ.get("SENTRY_DSN"),
+    environment=os.environ.get("ENV", "test"),
+    traces_sample_rate=1.0,
+    profiles_sample_rate=1.0,
+    debug=True,
+    _experiments={"trace_lifecycle": "stream"},
+)
+
+
+def index(request):
+    return Response("Hello from Pyramid!")
+
+
+def error(request):
+    raise ValueError("help! an error!")
+
+
+def message(request):
+    name = request.matchdict.get("name", "World")
+    return Response(f"Hello, {name}!")
+
+
+def create_app():
+    with Configurator() as config:
+        config.add_route("index", "/")
+        config.add_view(index, route_name="index")
+
+        config.add_route("error", "/error")
+        config.add_view(error, route_name="error")
+
+        config.add_route("message", "/message/{name}")
+        config.add_view(message, route_name="message")
+
+        app = config.make_wsgi_app()
+
+    return app
+
+
+if __name__ == "__main__":
+    app = create_app()
+    print("Serving on http://localhost:8000")
+    serve(app, host="0.0.0.0", port=8000)

--- a/test-pyramid/pyproject.toml
+++ b/test-pyramid/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "test-pyramid"
+version = "0"
+requires-python = ">=3.12"
+
+dependencies = [
+    "ipdb>=0.13.13",
+    "pyramid>=2.0",
+    "sentry-sdk[pyramid]",
+    "waitress>=3.0",
+]
+
+[tool.uv.sources]
+sentry-sdk = { path = "../../sentry-python", editable = true }

--- a/test-pyramid/run.sh
+++ b/test-pyramid/run.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# exit on first error
+set -euo pipefail
+
+# Install uv if it's not installed
+if ! command -v uv &> /dev/null; then
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
+
+# Run the script
+uv run python main.py


### PR DESCRIPTION
Adds a Pyramid test project for integration testing with the Sentry SDK.

Similar to the existing Strawberry and aiohttp test projects, this provides a test setup for the Pyramid web framework.

Closes PY-2350