### PR TITLE
build(test-django-asgi): Migrate to uv and pyproject.toml

### DIFF
--- a/test-django-asgi/pyproject.toml
+++ b/test-django-asgi/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "test-django-asgi"
+version = "0"
+requires-python = ">=3.12"
+
+dependencies = [
+    "django>=5.2",
+    "ipdb>=0.13.13",
+    "sentry-sdk[django]",
+    "uvicorn>=0.34.0",
+]
+
+[tool.uv.sources]
+sentry-sdk = { path = "../../sentry-python", editable = true }

--- a/test-django-asgi/requirements.txt
+++ b/test-django-asgi/requirements.txt
@@ -1,6 +1,0 @@
-Django
-uvicorn 
-
-ipdb
-
--e ../../../code/sentry-python  # sdk in a sibling folder to this projects folder

--- a/test-django-asgi/run.sh
+++ b/test-django-asgi/run.sh
@@ -1,16 +1,10 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
-# exit on first error
-set -xe
-
-# create and activate virtual environment
-python -m venv .venv
-source .venv/bin/activate
-
-# Install (or update) requirements
-python -m pip install -r requirements.txt
+if ! command -v uv &> /dev/null; then
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
 
 cd mysite
 
-# Run Django application on localhost:8000
-uvicorn mysite.asgi:application
+uv run uvicorn mysite.asgi:application


### PR DESCRIPTION
## Summary
- Replace `pip`/`requirements.txt` with `uv`/`pyproject.toml` for dependency management
- Update `run.sh` to use `uv run` instead of manual venv creation and pip install
- Remove legacy `requirements.txt`

Refs PY-2439

## Test plan
- [ ] Verify `pyproject.toml` includes all dependencies from the original `requirements.txt`
- [ ] Verify `run.sh` uses `uv run`
- [ ] Verify `requirements.txt` is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)