### PR TITLE
build(test-django-debug-toolbar): Migrate to uv and pyproject.toml

### DIFF
--- a/test-django-debug-toolbar/pyproject.toml
+++ b/test-django-debug-toolbar/pyproject.toml
@@ -1,0 +1,17 @@
+[project]
+name = "test-django-debug-toolbar"
+version = "0"
+requires-python = ">=3.12"
+
+dependencies = [
+    "django>=5.2",
+    "django-debug-toolbar>=5.0.1",
+    "ipdb>=0.13.13",
+    "psycopg>=3.2.6",
+    "sentry-sdk[django]",
+    "strawberry-graphql>=0.243.0",
+    "strawberry-graphql-django>=0.51.1",
+]
+
+[tool.uv.sources]
+sentry-sdk = { path = "../../sentry-python", editable = true }

--- a/test-django-debug-toolbar/requirements.txt
+++ b/test-django-debug-toolbar/requirements.txt
@@ -1,8 +1,0 @@
-Django
-psycopg  # connection to Postgres database
-django-debug-toolbar
-ipdb
-strawberry-graphql
-strawberry-graphql-django
-
--e ../../../code/sentry-python  # sdk in a sibling folder to this projects folder

--- a/test-django-debug-toolbar/run.sh
+++ b/test-django-debug-toolbar/run.sh
@@ -1,18 +1,8 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
-# exit on first error
-set -xe
+if ! command -v uv &> /dev/null; then
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
 
-# create and activate virtual environment
-python -m venv .venv
-source .venv/bin/activate
-
-# Install (or update) requirements
-python -m pip install -r requirements.txt
-
-# run migrations
-# ./manage.py migrate
-
-# Run Django application on localhost:8000
-./manage.py runserver 0.0.0.0:8000
-#gunicorn movie_search.project.asgi:application -k uvicorn.workers.UvicornWorker
+uv run ./manage.py runserver 0.0.0.0:8000


### PR DESCRIPTION
## Summary
- Replace `pip`/`requirements.txt` with `uv`/`pyproject.toml` for dependency management
- Update `run.sh` to use `uv run` instead of manual venv creation and pip install
- Remove legacy `requirements.txt`

Refs PY-2443

## Test plan
- [ ] Verify `pyproject.toml` includes all dependencies from the original `requirements.txt`
- [ ] Verify `run.sh` uses `uv run`
- [ ] Verify `requirements.txt` is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)