### PR TITLE
build(test-django-rest-framework-streaming): Migrate to uv and pyproject.toml

### DIFF
--- a/test-django-rest-framework-streaming/pyproject.toml
+++ b/test-django-rest-framework-streaming/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+name = "test-django-rest-framework-streaming"
+version = "0"
+requires-python = ">=3.12"
+
+dependencies = [
+    "django>=5.2",
+    "djangorestframework>=3.16.0",
+    "gunicorn>=23.0.0",
+    "ipdb>=0.13.13",
+    "sentry-sdk[django]",
+    "uvicorn>=0.34.0",
+]
+
+[tool.uv.sources]
+sentry-sdk = { path = "../../sentry-python", editable = true }

--- a/test-django-rest-framework-streaming/requirements.txt
+++ b/test-django-rest-framework-streaming/requirements.txt
@@ -1,9 +1,0 @@
-Django
-djangorestframework
-
-ipdb
-
--e ../../../code/sentry-python  # sdk in a sibling folder to this projects folder
-
-gunicorn
-uvicorn

--- a/test-django-rest-framework-streaming/run.sh
+++ b/test-django-rest-framework-streaming/run.sh
@@ -1,19 +1,8 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
-# exit on first error
-set -xe
+if ! command -v uv &> /dev/null; then
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
 
-# create and activate virtual environment
-python -m venv .venv
-source .venv/bin/activate
-
-# Install (or update) requirements
-python -m pip install -r requirements.txt
-
-# run migrations
-# ./manage.py migrate
-
-# Run Django application on localhost:8000
-# ./manage.py runserver 0.0.0.0:8000
-# uvicorn mysite.asgi:application
-gunicorn mysite.wsgi:application
+uv run gunicorn mysite.wsgi:application


### PR DESCRIPTION
## Summary
- Replace `pip`/`requirements.txt` with `uv`/`pyproject.toml` for dependency management
- Update `run.sh` to use `uv run` instead of manual venv creation and pip install
- Remove legacy `requirements.txt`

Refs PY-2444

## Test plan
- [ ] Verify `pyproject.toml` includes all dependencies from the original `requirements.txt`
- [ ] Verify `run.sh` uses `uv run`
- [ ] Verify `requirements.txt` is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)