### PR TITLE
build(test-django-rest-framework-xml): Migrate to uv and pyproject.toml

### DIFF
--- a/test-django-rest-framework-xml/pyproject.toml
+++ b/test-django-rest-framework-xml/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+name = "test-django-rest-framework-xml"
+version = "0"
+requires-python = ">=3.12"
+
+dependencies = [
+    "channels[daphne]>=4.2.0",
+    "django==4.1a1",
+    "django-debug-toolbar>=5.0.1",
+    "ipdb>=0.13.13",
+    "psycopg>=3.2.6",
+    "sentry-sdk[django]",
+]
+
+[tool.uv.sources]
+sentry-sdk = { path = "../../sentry-python", editable = true }

--- a/test-django-rest-framework-xml/requirements.txt
+++ b/test-django-rest-framework-xml/requirements.txt
@@ -1,8 +1,0 @@
-Django==4.1a1
-psycopg  # connection to Postgres database
-ipdb
-django-debug-toolbar
-
-channels[daphne]
-
--e ../../../code/sentry-python  # sdk in a sibling folder to this projects folder

--- a/test-django-rest-framework-xml/run.sh
+++ b/test-django-rest-framework-xml/run.sh
@@ -1,20 +1,10 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
-# exit on first error
-set -xe
+if ! command -v uv &> /dev/null; then
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
 
-# create and activate virtual environment
-python -m venv .venv
-source .venv/bin/activate
-
-# Install (or update) requirements
-python -m pip install -r requirements.txt
-
-# run migrations
-# ./manage.py migrate
-
-# Run Django application on localhost:8000
 cd mysite
-daphne -b 0.0.0.0 -p 8000 mysite.asgi:application
-# ./manage.py runserver 0.0.0.0:8000
-#gunicorn movie_search.project.asgi:application -k uvicorn.workers.UvicornWorker
+
+uv run daphne -b 0.0.0.0 -p 8000 mysite.asgi:application


### PR DESCRIPTION
## Summary
- Replace `pip`/`requirements.txt` with `uv`/`pyproject.toml` for dependency management
- Update `run.sh` to use `uv run` instead of manual venv creation and pip install
- Remove legacy `requirements.txt`

Refs PY-2445

## Test plan
- [ ] Verify `pyproject.toml` includes all dependencies from the original `requirements.txt`
- [ ] Verify `run.sh` uses `uv run`
- [ ] Verify `requirements.txt` is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)