### PR TITLE
build(test-dramatiq): Migrate to uv and pyproject.toml

### DIFF
--- a/test-dramatiq/pyproject.toml
+++ b/test-dramatiq/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "test-dramatiq"
+version = "0"
+requires-python = ">=3.12"
+
+dependencies = [
+    "dramatiq>=0.12.0",
+    "ipdb>=0.13.13",
+    "redis>=5.2.1",
+    "sentry-sdk",
+]
+
+[tool.uv.sources]
+sentry-sdk = { path = "../../sentry-python", editable = true }

--- a/test-dramatiq/requirements.txt
+++ b/test-dramatiq/requirements.txt
@@ -1,9 +1,0 @@
-dramatiq
-
-redis
-
-ipdb
-
-# Sentry
--e ../../../code/sentry-python  # local dev version of sentry python sdk.
-# sentry-sdk==2.8.0  # production version of sentry python sdk from PyPI.

--- a/test-dramatiq/run-worker.sh
+++ b/test-dramatiq/run-worker.sh
@@ -1,20 +1,14 @@
 #!/usr/bin/env bash
-
 set -euo pipefail
 reset
 
-# Create virtual environment
-python -m venv .venv
-source .venv/bin/activate
+if ! command -v uv &> /dev/null; then
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
 
-# Install requirements into virtual environment
-pip install -r requirements.txt
-
-# Start a fresh redis server
 pkill redis-server || true
 sleep 1
 rm -rf dump.rdb
 redis-server --daemonize yes
 
-# Start dramatiq worker
-dramatiq --processes 1 main
+uv run dramatiq --processes 1 main

--- a/test-dramatiq/run.sh
+++ b/test-dramatiq/run.sh
@@ -1,14 +1,9 @@
 #!/usr/bin/env bash
-
 set -euo pipefail
 reset
 
-# Create virtual environment
-python -m venv .venv
-source .venv/bin/activate
+if ! command -v uv &> /dev/null; then
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
 
-# Install requirements into virtual environment
-pip install -r requirements.txt
-
-# Run script that sends task to dramatiq worker
-python main.py
+uv run python main.py


### PR DESCRIPTION
## Summary
- Replace `pip`/`requirements.txt` with `uv`/`pyproject.toml` for dependency management
- Update `run.sh` and `run-worker.sh` to use `uv run` instead of manual venv creation and pip install
- Remove legacy `requirements.txt`

Refs PY-2446

## Test plan
- [ ] Verify `pyproject.toml` includes all dependencies from the original `requirements.txt`
- [ ] Verify shell scripts use `uv run`
- [ ] Verify `requirements.txt` is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)