### PR TITLE
build(test-error-sampler): Migrate to uv and pyproject.toml

### DIFF
--- a/test-error-sampler/pyproject.toml
+++ b/test-error-sampler/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "test-error-sampler"
+version = "0"
+requires-python = ">=3.12"
+
+dependencies = [
+    "ipdb>=0.13.13",
+    "sentry-sdk",
+]
+
+[tool.uv.sources]
+sentry-sdk = { path = "../../sentry-python", editable = true }

--- a/test-error-sampler/requirements.txt
+++ b/test-error-sampler/requirements.txt
@@ -1,4 +1,0 @@
-
--e  ../../../code/sentry-python
-
-ipdb

--- a/test-error-sampler/run.sh
+++ b/test-error-sampler/run.sh
@@ -1,12 +1,9 @@
 #!/usr/bin/env bash
-
 set -euo pipefail
-
 reset
 
-python -m venv .venv
-source .venv/bin/activate
+if ! command -v uv &> /dev/null; then
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
 
-pip install -r requirements.txt
-
-python main.py
+uv run python main.py


### PR DESCRIPTION
## Summary
- Replace `pip`/`requirements.txt` with `uv`/`pyproject.toml` for dependency management
- Update `run.sh` to use `uv run` instead of manual venv creation and pip install
- Remove legacy `requirements.txt`

Refs PY-2447

## Test plan
- [ ] Verify `pyproject.toml` includes all dependencies from the original `requirements.txt`
- [ ] Verify `run.sh` uses `uv run`
- [ ] Verify `requirements.txt` is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)