### PR TITLE
build(test-fastapi-background-tasks): Migrate to uv and pyproject.toml

### DIFF
--- a/test-fastapi-background-tasks/pyproject.toml
+++ b/test-fastapi-background-tasks/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "test-fastapi-background-tasks"
+version = "0"
+requires-python = ">=3.12"
+
+dependencies = [
+    "fastapi>=0.115.11",
+    "ipdb>=0.13.13",
+    "sentry-sdk[fastapi]",
+    "uvicorn>=0.34.0",
+]
+
+[tool.uv.sources]
+sentry-sdk = { path = "../../sentry-python", editable = true }

--- a/test-fastapi-background-tasks/requirements.txt
+++ b/test-fastapi-background-tasks/requirements.txt
@@ -1,8 +1,0 @@
-fastapi
-uvicorn
-
-ipdb
-
-# Sentry
--e ../../../code/sentry-python/  # local dev version of sentry python sdk.
-# sentry-sdk==2.11.0  # production version of sentry python sdk from PyPI.`

--- a/test-fastapi-background-tasks/run.sh
+++ b/test-fastapi-background-tasks/run.sh
@@ -1,15 +1,9 @@
 #!/usr/bin/env bash
-
 set -euo pipefail
-
 reset
 
-python -m venv .venv
-source .venv/bin/activate
+if ! command -v uv &> /dev/null; then
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
 
-pip install -r requirements.txt
-
-# uvicorn main:app --port 5000 --reload --root-path /api/v1 &
-uvicorn main:app --port 5000 --reload
-
-#nginx -c "$(pwd)/nginx.conf" 
+uv run uvicorn main:app --port 5000 --reload


### PR DESCRIPTION
## Summary
- Replace `pip`/`requirements.txt` with `uv`/`pyproject.toml` for dependency management
- Update `run.sh` to use `uv run` instead of manual venv creation and pip install
- Remove legacy `requirements.txt`

Refs PY-2448

## Test plan
- [ ] Verify `pyproject.toml` includes all dependencies from the original `requirements.txt`
- [ ] Verify `run.sh` uses `uv run`
- [ ] Verify `requirements.txt` is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)