### PR TITLE
build(test-flask-otel): Migrate to uv and pyproject.toml

### DIFF
--- a/test-flask-otel/pyproject.toml
+++ b/test-flask-otel/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+name = "test-flask-otel"
+version = "0"
+requires-python = ">=3.12"
+
+dependencies = [
+    "blinker>=1.9.0",
+    "flask>=3.1.1",
+    "ipdb>=0.13.13",
+    "markupsafe>=3.0.2",
+    "opentelemetry-distro>=0.52b0",
+    "sentry-sdk[flask]",
+]
+
+[tool.uv.sources]
+sentry-sdk = { path = "../../sentry-python", editable = true }

--- a/test-flask-otel/requirements.txt
+++ b/test-flask-otel/requirements.txt
@@ -1,9 +1,0 @@
-flask
-blinker
-markupsafe
-
-opentelemetry-distro
-
--e  ../../code/sentry-python
-
-ipdb

--- a/test-flask-otel/run.sh
+++ b/test-flask-otel/run.sh
@@ -1,14 +1,8 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
-# exit on first error
-set -xe
+if ! command -v uv &> /dev/null; then
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
 
-# create and activate virtual environment
-python -m venv .venv
-source .venv/bin/activate
-
-# Install (or update) requirements
-python -m pip install -r requirements.txt
-
-# Run Flask application on localhost:5000
-flask --app app run
+uv run flask --app app run


### PR DESCRIPTION
## Summary
- Replace `pip`/`requirements.txt` with `uv`/`pyproject.toml` for dependency management
- Update `run.sh` to use `uv run` instead of manual venv creation and pip install
- Remove legacy `requirements.txt`

Refs PY-2454

## Test plan
- [ ] Verify `pyproject.toml` includes all dependencies from the original `requirements.txt`
- [ ] Verify `run.sh` uses `uv run`
- [ ] Verify `requirements.txt` is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)