### PR TITLE
build(test-grpc): Migrate to uv and pyproject.toml

### DIFF
--- a/test-grpc/pyproject.toml
+++ b/test-grpc/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "test-grpc"
+version = "0"
+requires-python = ">=3.12"
+
+dependencies = [
+    "grpcio>=1.71.0",
+    "grpcio-tools>=1.71.0",
+    "ipdb>=0.13.13",
+    "sentry-sdk[grpcio]",
+]
+
+[tool.uv.sources]
+sentry-sdk = { path = "../../sentry-python", editable = true }

--- a/test-grpc/requirements.txt
+++ b/test-grpc/requirements.txt
@@ -1,6 +1,0 @@
--e ../../../code/sentry-python 
-
-grpcio
-grpcio-tools  # includes `protoc` compiler
-
-ipdb

--- a/test-grpc/run-client-aysnc.sh
+++ b/test-grpc/run-client-aysnc.sh
@@ -1,14 +1,8 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
-# exit on first error
-set -xe
+if ! command -v uv &> /dev/null; then
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
 
-# create and activate virtual environment
-python -m venv .venv
-source .venv/bin/activate
-
-# Install (or update) requirements
-python -m pip install -r requirements.txt
-
-
-python client-async.py
+uv run python client-async.py

--- a/test-grpc/run-client.sh
+++ b/test-grpc/run-client.sh
@@ -1,14 +1,8 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
-# exit on first error
-set -xe
+if ! command -v uv &> /dev/null; then
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
 
-# create and activate virtual environment
-python -m venv .venv
-source .venv/bin/activate
-
-# Install (or update) requirements
-python -m pip install -r requirements.txt
-
-
-python client.py
+uv run python client.py

--- a/test-grpc/run-server-async.sh
+++ b/test-grpc/run-server-async.sh
@@ -1,14 +1,8 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
-# exit on first error
-set -xe
+if ! command -v uv &> /dev/null; then
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
 
-# create and activate virtual environment
-python -m venv .venv
-source .venv/bin/activate
-
-# Install (or update) requirements
-python -m pip install -r requirements.txt
-
-
-python server-async.py
+uv run python server-async.py

--- a/test-grpc/run-server.sh
+++ b/test-grpc/run-server.sh
@@ -1,14 +1,8 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
-# exit on first error
-set -xe
+if ! command -v uv &> /dev/null; then
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
 
-# create and activate virtual environment
-python -m venv .venv
-source .venv/bin/activate
-
-# Install (or update) requirements
-python -m pip install -r requirements.txt
-
-
-python server.py
+uv run python server.py


### PR DESCRIPTION
## Summary
- Replace `pip`/`requirements.txt` with `uv`/`pyproject.toml` for dependency management
- Update all run scripts to use `uv run` instead of manual venv creation and pip install
- Remove legacy `requirements.txt`

Refs PY-2456

## Test plan
- [ ] Verify `pyproject.toml` includes all dependencies from the original `requirements.txt`
- [ ] Verify shell scripts use `uv run`
- [ ] Verify `requirements.txt` is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)