### PR TITLE
build(test-lambda-function): Migrate to uv and pyproject.toml

### DIFF
--- a/test-lambda-function/build.sh
+++ b/test-lambda-function/build.sh
@@ -1,11 +1,14 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
-set -ex
+if ! command -v uv &> /dev/null; then
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
 
 rm -rf lambda_function_package.zip
 rm -rf ./python_with_sentry/package/*
 
-pip install --target ./python_with_sentry/package -r requirements.txt
+uv pip install --target ./python_with_sentry/package -r pyproject.toml
 
 cd ./python_with_sentry/package && zip -x "**/__pycache__/*" -r ../../lambda_function_package.zip . && cd -
 

--- a/test-lambda-function/pyproject.toml
+++ b/test-lambda-function/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "test-lambda-function"
+version = "0"
+requires-python = ">=3.12"
+
+dependencies = [
+    "sentry-sdk",
+]
+
+[tool.uv.sources]
+sentry-sdk = { path = "../../sentry-python", editable = true }

--- a/test-lambda-function/requirements.txt
+++ b/test-lambda-function/requirements.txt
@@ -1,1 +1,0 @@
-sentry-sdk


### PR DESCRIPTION
## Summary
- Replace `pip`/`requirements.txt` with `uv`/`pyproject.toml` for dependency management
- Update `build.sh` to use `uv pip install` instead of `pip install`
- Remove legacy `requirements.txt`

Refs PY-2460

## Test plan
- [ ] Verify `pyproject.toml` includes all dependencies from the original `requirements.txt`
- [ ] Verify `build.sh` uses uv
- [ ] Verify `requirements.txt` is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)