### PR TITLE
build(test-litestar): Migrate to uv and pyproject.toml

### DIFF
--- a/test-litestar/pyproject.toml
+++ b/test-litestar/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "test-litestar"
+version = "0"
+requires-python = ">=3.12"
+
+dependencies = [
+    "ipdb>=0.13.13",
+    "litestar[brotli,cryptography]>=2.15.0",
+    "sentry-sdk[litestar]",
+    "uvicorn>=0.34.0",
+]
+
+[tool.uv.sources]
+sentry-sdk = { path = "../../sentry-python", editable = true }

--- a/test-litestar/requirements.txt
+++ b/test-litestar/requirements.txt
@@ -1,7 +1,0 @@
-litestar[brotli,cryptography]
-
-uvicorn
-
-ipdb
-
--e ../../../code/sentry-python  # sdk in a sibling folder to this projects folder

--- a/test-litestar/run.sh
+++ b/test-litestar/run.sh
@@ -1,15 +1,8 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
-# exit on first error
-set -xe
+if ! command -v uv &> /dev/null; then
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
 
-# create and activate virtual environment
-python -m venv .venv
-source .venv/bin/activate
-
-# Install (or update) requirements
-python -m pip install -r requirements.txt
-
-# Run litestar app
-# litestar run
-uvicorn app:app --reload
+uv run uvicorn app:app --reload


### PR DESCRIPTION
## Summary
- Replace `pip`/`requirements.txt` with `uv`/`pyproject.toml` for dependency management
- Update `run.sh` to use `uv run` instead of manual venv creation and pip install
- Remove legacy `requirements.txt`

Refs PY-2462

## Test plan
- [ ] Verify `pyproject.toml` includes all dependencies from the original `requirements.txt`
- [ ] Verify `run.sh` uses `uv run`
- [ ] Verify `requirements.txt` is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)