### PR TITLE
build(test-llm-manual-instrumentation): Migrate to uv and pyproject.toml

### DIFF
--- a/test-llm-manual-instrumentation/pyproject.toml
+++ b/test-llm-manual-instrumentation/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "test-llm-manual-instrumentation"
+version = "0"
+requires-python = ">=3.12"
+
+dependencies = [
+    "ipdb>=0.13.13",
+    "sentry-sdk",
+]
+
+[tool.uv.sources]
+sentry-sdk = { path = "../../sentry-python", editable = true }

--- a/test-llm-manual-instrumentation/requirements.txt
+++ b/test-llm-manual-instrumentation/requirements.txt
@@ -1,4 +1,0 @@
-
--e  ../../../code/sentry-python
-
-ipdb

--- a/test-llm-manual-instrumentation/run.sh
+++ b/test-llm-manual-instrumentation/run.sh
@@ -1,12 +1,9 @@
 #!/usr/bin/env bash
-
 set -euo pipefail
-
 reset
 
-python -m venv .venv
-source .venv/bin/activate
+if ! command -v uv &> /dev/null; then
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
 
-pip install -r requirements.txt
-
-python main.py
+uv run python main.py


### PR DESCRIPTION
## Summary
- Replace `pip`/`requirements.txt` with `uv`/`pyproject.toml` for dependency management
- Update `run.sh` to use `uv run` instead of manual venv creation and pip install
- Remove legacy `requirements.txt`

Refs PY-2463

## Test plan
- [ ] Verify `pyproject.toml` includes all dependencies from the original `requirements.txt`
- [ ] Verify `run.sh` uses `uv run`
- [ ] Verify `requirements.txt` is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)