### PR TITLE
build(test-logging-leak): Migrate to uv and pyproject.toml

### DIFF
--- a/test-logging-leak/pyproject.toml
+++ b/test-logging-leak/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "test-logging-leak"
+version = "0"
+requires-python = ">=3.12"
+
+dependencies = [
+    "aiohttp>=3.11.14",
+    "ipdb>=0.13.13",
+    "sentry-sdk[aiohttp]",
+]
+
+[tool.uv.sources]
+sentry-sdk = { path = "../../sentry-python", editable = true }

--- a/test-logging-leak/requirements.txt
+++ b/test-logging-leak/requirements.txt
@@ -1,5 +1,0 @@
-aiohttp
-
-ipdb
-
--e ../../../code/sentry-python 

--- a/test-logging-leak/run.sh
+++ b/test-logging-leak/run.sh
@@ -1,14 +1,8 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
-# exit on first error
-set -xe
+if ! command -v uv &> /dev/null; then
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
 
-# create and activate virtual environment
-python -m venv .venv
-source .venv/bin/activate
-
-# Install (or update) requirements
-python -m pip install -r requirements.txt
-
-
-python main.py
+uv run python main.py


### PR DESCRIPTION
## Summary
- Replace `pip`/`requirements.txt` with `uv`/`pyproject.toml` for dependency management
- Update `run.sh` to use `uv run` instead of manual venv creation and pip install
- Remove legacy `requirements.txt`

Refs PY-2464

## Test plan
- [ ] Verify `pyproject.toml` includes all dependencies from the original `requirements.txt`
- [ ] Verify `run.sh` uses `uv run`
- [ ] Verify `requirements.txt` is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)