### PR TITLE
build(test-multiprocessing): Migrate to uv and pyproject.toml

### DIFF
--- a/test-multiprocessing/pyproject.toml
+++ b/test-multiprocessing/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "test-multiprocessing"
+version = "0"
+requires-python = ">=3.12"
+
+dependencies = [
+    "ipdb>=0.13.13",
+    "sentry-sdk",
+]
+
+[tool.uv.sources]
+sentry-sdk = { path = "../../sentry-python", editable = true }

--- a/test-multiprocessing/requirements.txt
+++ b/test-multiprocessing/requirements.txt
@@ -1,5 +1,0 @@
-ipdb
-
-# Sentry
--e ../../../code/sentry-python/  # local dev version of sentry python sdk.
-# sentry-sdk==1.11.0  # production version of sentry python sdk from PyPI.

--- a/test-multiprocessing/run.sh
+++ b/test-multiprocessing/run.sh
@@ -1,12 +1,9 @@
 #!/usr/bin/env bash
-
 set -euo pipefail
-
 reset
 
-python -m venv .venv
-source .venv/bin/activate
+if ! command -v uv &> /dev/null; then
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
 
-pip install -r requirements.txt
-
-python main.py
+uv run python main.py


### PR DESCRIPTION
## Summary
- Replace `pip`/`requirements.txt` with `uv`/`pyproject.toml` for dependency management
- Update `run.sh` to use `uv run` instead of manual venv creation and pip install
- Remove legacy `requirements.txt`

Refs PY-2465

## Test plan
- [ ] Verify `pyproject.toml` includes all dependencies from the original `requirements.txt`
- [ ] Verify `run.sh` uses `uv run`
- [ ] Verify `requirements.txt` is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)