### PR TITLE
build(test-plain-python-generators): Migrate to uv and pyproject.toml

### DIFF
--- a/test-plain-python-generators/pyproject.toml
+++ b/test-plain-python-generators/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "test-plain-python-generators"
+version = "0"
+requires-python = ">=3.12"
+
+dependencies = [
+    "ipdb>=0.13.13",
+    "sentry-sdk",
+]
+
+[tool.uv.sources]
+sentry-sdk = { path = "../../sentry-python", editable = true }

--- a/test-plain-python-generators/requirements.txt
+++ b/test-plain-python-generators/requirements.txt
@@ -1,4 +1,0 @@
-
--e  ../../../code/sentry-python
-
-ipdb

--- a/test-plain-python-generators/run.sh
+++ b/test-plain-python-generators/run.sh
@@ -1,12 +1,9 @@
 #!/usr/bin/env bash
-
 set -euo pipefail
-
 reset
 
-python -m venv .venv
-source .venv/bin/activate
+if ! command -v uv &> /dev/null; then
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
 
-pip install -r requirements.txt
-
-python main.py
+uv run python main.py


### PR DESCRIPTION
## Summary
- Replace `pip`/`requirements.txt` with `uv`/`pyproject.toml` for dependency management
- Update `run.sh` to use `uv run`
- Remove legacy `requirements.txt`

Refs PY-2468

🤖 Generated with [Claude Code](https://claude.com/claude-code)