### PR TITLE
build(test-long-running-transaction): Migrate to uv and pyproject.toml

### DIFF
--- a/test-long-running-transaction/pyproject.toml
+++ b/test-long-running-transaction/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "test-long-running-transaction"
+version = "0"
+requires-python = ">=3.12"
+
+dependencies = [
+    "ipdb>=0.13.13",
+    "sentry-sdk",
+    "Werkzeug<2.1.0",
+]
+
+[tool.uv.sources]
+sentry-sdk = { path = "../../sentry-python", editable = true }

--- a/test-long-running-transaction/requirements.txt
+++ b/test-long-running-transaction/requirements.txt
@@ -1,6 +1,0 @@
-
--e  ../../../code/sentry-python
-
-Werkzeug<2.1.0
-
-ipdb

--- a/test-long-running-transaction/run.sh
+++ b/test-long-running-transaction/run.sh
@@ -1,12 +1,9 @@
 #!/usr/bin/env bash
-
 set -euo pipefail
-
 reset
 
-python -m venv .venv
-source .venv/bin/activate
+if ! command -v uv &> /dev/null; then
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
 
-pip install -r requirements.txt
-
-python main.py
+uv run python main.py


### PR DESCRIPTION
## Summary
- Replace pip/requirements.txt with uv/pyproject.toml for dependency management
- Update run.sh to use uv run
- Remove legacy requirements.txt

Refs PY-2469

🤖 Generated with [Claude Code](https://claude.com/claude-code)