### PR TITLE
build(test-python312): Migrate to uv and pyproject.toml

### DIFF
--- a/test-python312/pyproject.toml
+++ b/test-python312/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "test-python312"
+version = "0"
+requires-python = ">=3.12"
+
+dependencies = [
+    "ipdb>=0.13.13",
+    "sanic>=24.12.0",
+    "sentry-sdk[sanic]",
+]
+
+[tool.uv.sources]
+sentry-sdk = { path = "../../sentry-python", editable = true }

--- a/test-python312/requirements.txt
+++ b/test-python312/requirements.txt
@@ -1,5 +1,0 @@
-sanic
-
-ipdb
-
--e ../../../code/sentry-python 

--- a/test-python312/run-sanic.sh
+++ b/test-python312/run-sanic.sh
@@ -1,14 +1,8 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
-# exit on first error
-set -xe
+if ! command -v uv &> /dev/null; then
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
 
-# create and activate virtual environment
-python -m venv .venv
-source .venv/bin/activate
-
-# Install (or update) requirements
-python -m pip install -r requirements.txt
-
-
-sanic server
+uv run sanic server

--- a/test-python312/run.sh
+++ b/test-python312/run.sh
@@ -1,14 +1,8 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
-# exit on first error
-set -xe
+if ! command -v uv &> /dev/null; then
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
 
-# create and activate virtual environment
-python -m venv .venv
-source .venv/bin/activate
-
-# Install (or update) requirements
-python -m pip install -r requirements.txt
-
-
-python main.py
+uv run python main.py


### PR DESCRIPTION
## Summary
- Replace pip/requirements.txt with uv/pyproject.toml
- Update run.sh and run-sanic.sh to use uv run
- Remove legacy requirements.txt

Refs PY-2471

🤖 Generated with [Claude Code](https://claude.com/claude-code)