### PR TITLE
build(test-starlette): Migrate from pip to uv

### DIFF
--- a/test-starlette/pyproject.toml
+++ b/test-starlette/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "test-starlette"
+version = "0"
+requires-python = ">=3.12"
+
+dependencies = [
+    "ipdb>=0.13.13",
+    "starlette>=0.46.1",
+    "uvicorn>=0.34.0",
+    "sentry-sdk[starlette]",
+]
+
+[tool.uv.sources]
+sentry-sdk = { path = "../../sentry-python", editable = true }

--- a/test-starlette/requirements.txt
+++ b/test-starlette/requirements.txt
@@ -1,7 +1,0 @@
-starlette
-
-uvicorn
-
-ipdb
-
--e ../../../code/sentry-python  # sdk in a sibling folder to this projects folder

--- a/test-starlette/run.sh
+++ b/test-starlette/run.sh
@@ -1,14 +1,8 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
-# exit on first error
-set -xe
+if ! command -v uv &> /dev/null; then
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
 
-# create and activate virtual environment
-python -m venv .venv
-source .venv/bin/activate
-
-# Install (or update) requirements
-python -m pip install -r requirements.txt
-
-# Run starlette app
-uvicorn main:app --reload
+uv run uvicorn main:app --reload


### PR DESCRIPTION
## Summary
- Replace `requirements.txt` with `pyproject.toml` for dependency management
- Update `run.sh` to use `uv run` instead of manual venv/pip workflow
- Part of PY-2428 migration effort

## Test plan
- [ ] Run `./run.sh` and verify the starlette app starts with uvicorn

🤖 Generated with [Claude Code](https://claude.com/claude-code)