### PR TITLE
build(test-streamlit): Migrate from pip to uv

### DIFF
--- a/test-streamlit/pyproject.toml
+++ b/test-streamlit/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "test-streamlit"
+version = "0"
+requires-python = ">=3.12"
+
+dependencies = [
+    "ipdb>=0.13.13",
+    "numpy>=2.2.4",
+    "streamlit>=1.43.2",
+    "sentry-sdk",
+]
+
+[tool.uv.sources]
+sentry-sdk = { path = "../../sentry-python", editable = true }

--- a/test-streamlit/requirements.txt
+++ b/test-streamlit/requirements.txt
@@ -1,6 +1,0 @@
-streamlit
-numpy
-
-ipdb
-
--e ../../../code/sentry-python  # sdk in a sibling folder to this projects folder

--- a/test-streamlit/run.sh
+++ b/test-streamlit/run.sh
@@ -1,14 +1,8 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
-# exit on first error
-set -xe
+if ! command -v uv &> /dev/null; then
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
 
-# create and activate virtual environment
-python -m venv .venv
-source .venv/bin/activate
-
-# Install (or update) requirements
-python -m pip install -r requirements.txt
-
-
-streamlit run main.py
+uv run streamlit run main.py


### PR DESCRIPTION
## Summary
- Replace `requirements.txt` with `pyproject.toml` for dependency management
- Update `run.sh` to use `uv run` instead of manual venv/pip workflow
- Part of PY-2428 migration effort

## Test plan
- [ ] Run `./run.sh` and verify the streamlit app starts correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)