### PR TITLE
build(test-structlog-sentry): Migrate from pip to uv

### DIFF
--- a/test-structlog-sentry/pyproject.toml
+++ b/test-structlog-sentry/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "test-structlog-sentry"
+version = "0"
+requires-python = ">=3.12"
+
+dependencies = [
+    "ipdb>=0.13.13",
+    "structlog-sentry>=2.2.1",
+    "sentry-sdk",
+]
+
+[tool.uv.sources]
+sentry-sdk = { path = "../../sentry-python", editable = true }

--- a/test-structlog-sentry/requirements.txt
+++ b/test-structlog-sentry/requirements.txt
@@ -1,5 +1,0 @@
-structlog-sentry
-
-ipdb
-
--e ../../../code/sentry-python  # sdk in a sibling folder to this projects folder

--- a/test-structlog-sentry/run.sh
+++ b/test-structlog-sentry/run.sh
@@ -1,16 +1,8 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
-# exit on first error
-set -xe
+if ! command -v uv &> /dev/null; then
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
 
-reset 
-
-# create and activate virtual environment
-python -m venv .venv
-source .venv/bin/activate
-
-# Install (or update) requirements
-python -m pip install -r requirements.txt
-
-# Run app
-python main.py
+uv run python main.py


### PR DESCRIPTION
## Summary
- Replace `requirements.txt` with `pyproject.toml` for dependency management
- Update `run.sh` to use `uv run` instead of manual venv/pip workflow
- Part of PY-2428 migration effort

## Test plan
- [ ] Run `./run.sh` and verify the app runs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)