### PR TITLE
build(test-threading-logger): Migrate from pip to uv

### DIFF
--- a/test-threading-logger/pyproject.toml
+++ b/test-threading-logger/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "test-threading-logger"
+version = "0"
+requires-python = ">=3.12"
+
+dependencies = [
+    "ipdb>=0.13.13",
+    "sentry-sdk",
+]
+
+[tool.uv.sources]
+sentry-sdk = { path = "../../sentry-python", editable = true }

--- a/test-threading-logger/requirements.txt
+++ b/test-threading-logger/requirements.txt
@@ -1,5 +1,0 @@
-ipdb
-
-# Sentry
--e ../../../code/sentry-python/  # local dev version of sentry python sdk.
-# sentry-sdk==1.11.0  # production version of sentry python sdk from PyPI.

--- a/test-threading-logger/run.sh
+++ b/test-threading-logger/run.sh
@@ -1,12 +1,8 @@
 #!/usr/bin/env bash
-
 set -euo pipefail
 
-reset
+if ! command -v uv &> /dev/null; then
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
 
-python -m venv .venv
-source .venv/bin/activate
-
-pip install -r requirements.txt
-
-python main.py
+uv run python main.py


### PR DESCRIPTION
## Summary
- Replace `requirements.txt` with `pyproject.toml` for dependency management
- Update `run.sh` to use `uv run` instead of manual venv/pip workflow
- Part of PY-2428 migration effort

## Test plan
- [ ] Run `./run.sh` and verify the app runs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)