### PR TITLE
build(test-tracing-twp-dsc): Migrate from pip to uv

### DIFF
--- a/test-tracing-twp-dsc/pyproject.toml
+++ b/test-tracing-twp-dsc/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+name = "test-tracing-twp-dsc"
+version = "0"
+requires-python = ">=3.12"
+
+dependencies = [
+    "aiohttp>=3.11.14",
+    "fastapi>=0.115.11",
+    "honcho>=2.0.0",
+    "ipdb>=0.13.13",
+    "uvicorn>=0.34.0",
+    "sentry-sdk[fastapi]",
+]
+
+[tool.uv.sources]
+sentry-sdk = { path = "../../sentry-python", editable = true }

--- a/test-tracing-twp-dsc/requirements.txt
+++ b/test-tracing-twp-dsc/requirements.txt
@@ -1,9 +1,0 @@
-fastapi
-uvicorn
-
-aiohttp 
-
-ipdb
-honcho
-
--e  ../../../code/sentry-python

--- a/test-tracing-twp-dsc/run.sh
+++ b/test-tracing-twp-dsc/run.sh
@@ -1,11 +1,8 @@
 #!/usr/bin/env bash
-
 set -euo pipefail
 
-python -m venv .venv
-source .venv/bin/activate
+if ! command -v uv &> /dev/null; then
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
 
-pip install -r requirements.txt
-
-# see Procfile for the commands that are run
-honcho start
+uv run honcho start


### PR DESCRIPTION
## Summary
- Replace `requirements.txt` with `pyproject.toml` for dependency management
- Update `run.sh` to use `uv run` instead of manual venv/pip workflow
- Part of PY-2428 migration effort

## Test plan
- [ ] Run `./run.sh` and verify honcho starts the services correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)