### PR TITLE
build(tmp-celery-flush): Migrate from pip to uv

### DIFF
--- a/tmp-celery-flush/pyproject.toml
+++ b/tmp-celery-flush/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "tmp-celery-flush"
+version = "0"
+requires-python = ">=3.12"
+
+dependencies = [
+    "celery>=5.4.0",
+    "ipdb>=0.13.13",
+    "redis>=5.2.1",
+    "sentry-sdk[celery]",
+]
+
+[tool.uv.sources]
+sentry-sdk = { path = "../../sentry-python", editable = true }

--- a/tmp-celery-flush/requirements.txt
+++ b/tmp-celery-flush/requirements.txt
@@ -1,6 +1,0 @@
-celery
-redis
-
-ipdb
-
--e ../../../code/sentry-python  # sdk in a sibling folder to this projects folder

--- a/tmp-celery-flush/run-celery.sh
+++ b/tmp-celery-flush/run-celery.sh
@@ -1,19 +1,12 @@
 #!/usr/bin/env bash
-
-# exit on first error
 set -euo pipefail
 
-reset
-
-# create and activate virtual environment
-python -m venv .venv
-source .venv/bin/activate
-
-# Install (or update) requirements
-pip install -r requirements.txt
+if ! command -v uv &> /dev/null; then
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
 
 redis-server --daemonize yes
 
-celery -A tasks.app worker \
+uv run celery -A tasks.app worker \
     --loglevel=INFO \
     -c 1

--- a/tmp-celery-flush/start-task.sh
+++ b/tmp-celery-flush/start-task.sh
@@ -1,11 +1,8 @@
 #!/usr/bin/env bash
-
-# exit on first error
 set -euo pipefail
 
-# create and activate virtual environment
-python -m venv .venv
-source .venv/bin/activate
+if ! command -v uv &> /dev/null; then
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
 
-# Start task
-python -c 'import tasks; tasks.my_task.delay()'
+uv run python -c 'import tasks; tasks.my_task.delay()'


### PR DESCRIPTION
## Summary
- Replace `requirements.txt` with `pyproject.toml` for dependency management
- Update `run-celery.sh` and `start-task.sh` to use `uv run` instead of manual venv/pip workflow
- Part of PY-2428 migration effort

## Test plan
- [ ] Run `./run-celery.sh` and verify the celery worker starts correctly
- [ ] Run `./start-task.sh` and verify the task is dispatched

🤖 Generated with [Claude Code](https://claude.com/claude-code)