### PR TITLE
fix(test-fastapi-with-database): Fix sentry-sdk source path

### DIFF
--- a/test-fastapi-with-database/pyproject.toml
+++ b/test-fastapi-with-database/pyproject.toml
@@ -11,4 +11,4 @@ dependencies = [
 ]
 
 [tool.uv.sources]
-sentry-sdk = { path = "/sentry-python", editable = true }
+sentry-sdk = { path = "../../sentry-python", editable = true }


### PR DESCRIPTION
## Summary
- Fix sentry-sdk path from `/sentry-python` to `../../sentry-python` in pyproject.toml
- Part of PY-2428 migration effort

## Test plan
- [ ] Verify `uv sync` resolves sentry-sdk correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)