### PR TITLE
chore(test-plain-python-exception-groups): Remove legacy requirements.txt

### DIFF
--- a/test-plain-python-exception-groups/requirements.txt
+++ b/test-plain-python-exception-groups/requirements.txt
@@ -1,4 +1,0 @@
-
--e  ../../../code/sentry-python
-
-ipdb


### PR DESCRIPTION
## Summary
- Remove leftover `requirements.txt` (project already has `pyproject.toml` and uv-based `run.sh`)
- Part of PY-2428 migration effort

## Test plan
- [ ] Verify `./run.sh` still works without requirements.txt

🤖 Generated with [Claude Code](https://claude.com/claude-code)