### PR TITLE
build(test-potel-aws-lambda): Migrate from pip to uv

### DIFF
--- a/test-potel-aws-lambda/deploy.sh
+++ b/test-potel-aws-lambda/deploy.sh
@@ -53,11 +53,12 @@ echo "Creating temporary directory: $TEMP_DIR"
 echo "Copying function code..."
 cp -r lambda_function/* $TEMP_DIR/
 
-# Create virtual environment and install dependencies
+# Install dependencies
 echo "Setting up Python environment..."
-python -m venv $TEMP_DIR/.venv
-source $TEMP_DIR/.venv/bin/activate
-pip install -r $TEMP_DIR/requirements.txt -t $TEMP_DIR/
+if ! command -v uv &> /dev/null; then
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
+uv pip install --system --no-cache -r $TEMP_DIR/pyproject.toml --target $TEMP_DIR/
 
 # Create deployment package
 echo "Creating deployment package..."

--- a/test-potel-aws-lambda/lambda_function/pyproject.toml
+++ b/test-potel-aws-lambda/lambda_function/pyproject.toml
@@ -1,0 +1,8 @@
+[project]
+name = "test-potel-aws-lambda"
+version = "0"
+requires-python = ">=3.12"
+
+dependencies = [
+    "sentry-sdk>=3.0.0a1",
+]

--- a/test-potel-aws-lambda/lambda_function/requirements.txt
+++ b/test-potel-aws-lambda/lambda_function/requirements.txt
@@ -1,1 +1,0 @@
-sentry-sdk==3.0.0a1


### PR DESCRIPTION
## Summary
- Replace `lambda_function/requirements.txt` with `lambda_function/pyproject.toml`
- Update `deploy.sh` to use `uv pip install` instead of pip for Lambda packaging
- Part of PY-2428 migration effort

## Test plan
- [ ] Run `./deploy.sh` and verify the Lambda function deploys correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)