### PR TITLE
build(test-asyncio): Migrate from pip to uv

### DIFF
--- a/test-asyncio/pyproject.toml
+++ b/test-asyncio/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "test-asyncio"
+version = "0"
+requires-python = ">=3.12"
+
+dependencies = [
+    "ipdb>=0.13.13",
+    "sentry-sdk",
+]
+
+[tool.uv.sources]
+sentry-sdk = { path = "../../sentry-python", editable = true }

--- a/test-asyncio/requirements.txt
+++ b/test-asyncio/requirements.txt
@@ -1,4 +1,0 @@
-
--e  ../../../code/sentry-python
-
-ipdb

--- a/test-asyncio/run.sh
+++ b/test-asyncio/run.sh
@@ -1,12 +1,8 @@
 #!/usr/bin/env bash
-
 set -euo pipefail
 
-reset
+if ! command -v uv &> /dev/null; then
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
 
-python -m venv .venv
-source .venv/bin/activate
-
-pip install -r requirements.txt
-
-python main.py
+uv run python main.py


### PR DESCRIPTION
## Summary
- Replace `requirements.txt` with `pyproject.toml` for dependency management
- Update `run.sh` to use `uv run` instead of manual venv/pip workflow
- Part of PY-2428 migration effort

## Test plan
- [ ] Run `./run.sh` and verify the app runs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)