### PR TITLE
build(test-asyncpg): Migrate from pip to uv

### DIFF
--- a/test-asyncpg/pyproject.toml
+++ b/test-asyncpg/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "test-asyncpg"
+version = "0"
+requires-python = ">=3.12"
+
+dependencies = [
+    "asyncpg>=0.30.0",
+    "ipdb>=0.13.13",
+    "sentry-sdk[asyncpg]",
+]
+
+[tool.uv.sources]
+sentry-sdk = { path = "../../sentry-python", editable = true }

--- a/test-asyncpg/requirements.txt
+++ b/test-asyncpg/requirements.txt
@@ -1,5 +1,0 @@
-asyncpg
-
--e ../../../code/sentry-python 
-
-ipdb

--- a/test-asyncpg/run.sh
+++ b/test-asyncpg/run.sh
@@ -1,13 +1,8 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
-# exit on first error
-set -xe
+if ! command -v uv &> /dev/null; then
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
 
-# create and activate virtual environment
-python -m venv .venv
-source .venv/bin/activate
-
-# Install (or update) requirements
-python -m pip install -r requirements.txt
-
-python main.py
+uv run python main.py


### PR DESCRIPTION
## Summary
- Replace `requirements.txt` with `pyproject.toml` for dependency management
- Update `run.sh` to use `uv run` instead of manual venv/pip workflow
- Part of PY-2428 migration effort

## Test plan
- [ ] Run `./run.sh` and verify the app runs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)