### PR TITLE
build(test-celery-beat-parent-span-id): Migrate from pip to uv

### DIFF
--- a/test-celery-beat-parent-span-id/pyproject.toml
+++ b/test-celery-beat-parent-span-id/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "test-celery-beat-parent-span-id"
+version = "0"
+requires-python = ">=3.12"
+
+dependencies = [
+    "celery>=5.4.0",
+    "flask>=3.1.0",
+    "ipdb>=0.13.13",
+    "redis>=5.2.1",
+    "sentry-sdk[celery,flask]",
+]
+
+[tool.uv.sources]
+sentry-sdk = { path = "../../sentry-python", editable = true }

--- a/test-celery-beat-parent-span-id/requirements.txt
+++ b/test-celery-beat-parent-span-id/requirements.txt
@@ -1,8 +1,0 @@
-flask
-
-celery
-redis
-
-ipdb
-
--e ../../../code/sentry-python  # sdk in a sibling folder to this projects folder

--- a/test-celery-beat-parent-span-id/run-beat.sh
+++ b/test-celery-beat-parent-span-id/run-beat.sh
@@ -1,18 +1,11 @@
 #!/usr/bin/env bash
-
-# exit on first error
 set -euo pipefail
 
-reset
-
-# create and activate virtual environment
-python -m venv .venv
-source .venv/bin/activate
-
-# Install (or update) requirements
-pip install -r requirements.txt
+if ! command -v uv &> /dev/null; then
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
 
 redis-server --daemonize yes
 
-celery -A tasks.app beat \
+uv run celery -A tasks.app beat \
     --loglevel=INFO

--- a/test-celery-beat-parent-span-id/run-celery.sh
+++ b/test-celery-beat-parent-span-id/run-celery.sh
@@ -1,19 +1,12 @@
 #!/usr/bin/env bash
-
-# exit on first error
 set -euo pipefail
 
-reset
-
-# create and activate virtual environment
-python -m venv .venv
-source .venv/bin/activate
-
-# Install (or update) requirements
-pip install -r requirements.txt
+if ! command -v uv &> /dev/null; then
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
 
 redis-server --daemonize yes
 
-celery -A tasks.app worker \
+uv run celery -A tasks.app worker \
     --loglevel=INFO \
     -c 1

--- a/test-celery-beat-parent-span-id/run-flask.sh
+++ b/test-celery-beat-parent-span-id/run-flask.sh
@@ -1,17 +1,10 @@
 #!/usr/bin/env bash
-
-# exit on first error
 set -euo pipefail
 
-reset
-
-# create and activate virtual environment
-python -m venv .venv
-source .venv/bin/activate
-
-# Install (or update) requirements
-pip install -r requirements.txt
+if ! command -v uv &> /dev/null; then
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
 
 redis-server --daemonize yes
 
-flask --app main run
+uv run flask --app main run

--- a/test-celery-beat-parent-span-id/start-task.sh
+++ b/test-celery-beat-parent-span-id/start-task.sh
@@ -1,11 +1,4 @@
 #!/usr/bin/env bash
-
-# exit on first error
 set -euo pipefail
 
-# create and activate virtual environment
-python -m venv .venv
-source .venv/bin/activate
-
-# Start task
 curl -i -X GET http://localhost:5000/


### PR DESCRIPTION
## Summary
- Replace `requirements.txt` with `pyproject.toml` for dependency management
- Update `run-beat.sh`, `run-celery.sh`, `run-flask.sh`, and `start-task.sh` to use `uv run`
- Part of PY-2428 migration effort

## Test plan
- [ ] Run `./run-celery.sh` and verify the celery worker starts
- [ ] Run `./run-beat.sh` and verify celery beat starts
- [ ] Run `./run-flask.sh` and verify the Flask app starts
- [ ] Run `./start-task.sh` to trigger a task

🤖 Generated with [Claude Code](https://claude.com/claude-code)