### PR TITLE
build(test-celery-max-tasks-per-child): Migrate from pip to uv

### DIFF
--- a/test-celery-max-tasks-per-child/pyproject.toml
+++ b/test-celery-max-tasks-per-child/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "test-celery-max-tasks-per-child"
+version = "0"
+requires-python = ">=3.12"
+
+dependencies = [
+    "celery>=5.4.0",
+    "ipdb>=0.13.13",
+    "redis>=5.2.1",
+    "sentry-sdk[celery]",
+]
+
+[tool.uv.sources]
+sentry-sdk = { path = "../../sentry-python", editable = true }

--- a/test-celery-max-tasks-per-child/requirements.txt
+++ b/test-celery-max-tasks-per-child/requirements.txt
@@ -1,7 +1,0 @@
-celery
-redis
-
-ipdb
-
-
--e ../../../code/sentry-python  # sdk in a sibling folder to this projects folder

--- a/test-celery-max-tasks-per-child/run-celery.sh
+++ b/test-celery-max-tasks-per-child/run-celery.sh
@@ -1,25 +1,16 @@
 #!/usr/bin/env bash
-
-# exit on first error
 set -euo pipefail
 
-reset
-
-# create and activate virtual environment
-python -m venv .venv
-source .venv/bin/activate
-
-# Install (or update) requirements
-pip install -r requirements.txt
-
-reset 
+if ! command -v uv &> /dev/null; then
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
 
 redis-server --daemonize yes
 
 export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
 
-celery -A tasks.app worker \
+uv run celery -A tasks.app worker \
     --loglevel=DEBUG \
     -B \
     -c 1 \
-    --max-tasks-per-child 10000 # > output.txt 2> error.txt
+    --max-tasks-per-child 10000

--- a/test-celery-max-tasks-per-child/run.sh
+++ b/test-celery-max-tasks-per-child/run.sh
@@ -1,15 +1,8 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
-# exit on first error
-set -xe
+if ! command -v uv &> /dev/null; then
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
 
-reset
-
-# create and activate virtual environment
-python -m venv .venv
-source .venv/bin/activate
-
-# Install (or update) requirements
-python -m pip install -r requirements.txt
-
-python main.py
+uv run python main.py


### PR DESCRIPTION
## Summary
- Replace `requirements.txt` with `pyproject.toml` for dependency management
- Update `run.sh` and `run-celery.sh` to use `uv run` instead of manual venv/pip workflow
- Part of PY-2428 migration effort

## Test plan
- [ ] Run `./run-celery.sh` and verify the celery worker starts
- [ ] Run `./run.sh` and verify the app runs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)