### PR TITLE
build(test-celery-sentry-propagate-traces): Migrate from pip to uv

### DIFF
--- a/test-celery-sentry-propagate-traces/pyproject.toml
+++ b/test-celery-sentry-propagate-traces/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "test-celery-sentry-propagate-traces"
+version = "0"
+requires-python = ">=3.12"
+
+dependencies = [
+    "celery>=5.4.0",
+    "ipdb>=0.13.13",
+    "redis>=5.2.1",
+    "sentry-sdk[celery]",
+]
+
+[tool.uv.sources]
+sentry-sdk = { path = "../../sentry-python", editable = true }

--- a/test-celery-sentry-propagate-traces/requirements.txt
+++ b/test-celery-sentry-propagate-traces/requirements.txt
@@ -1,6 +1,0 @@
-celery
-redis
-
--e ../../../code/sentry-python 
-
-ipdb

--- a/test-celery-sentry-propagate-traces/run-celery.sh
+++ b/test-celery-sentry-propagate-traces/run-celery.sh
@@ -1,17 +1,10 @@
 #!/usr/bin/env bash
-
-# exit on first error
 set -euo pipefail
 
-reset
-
-# create and activate virtual environment
-python -m venv .venv
-source .venv/bin/activate
-
-# Install (or update) requirements
-pip install -r requirements.txt
+if ! command -v uv &> /dev/null; then
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
 
 redis-server --daemonize yes
 
-celery -A tasks.app worker --loglevel=DEBUG -c 1
+uv run celery -A tasks.app worker --loglevel=DEBUG -c 1

--- a/test-celery-sentry-propagate-traces/run.sh
+++ b/test-celery-sentry-propagate-traces/run.sh
@@ -1,15 +1,8 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
-# exit on first error
-set -xe
+if ! command -v uv &> /dev/null; then
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
 
-reset
-
-# create and activate virtual environment
-python -m venv .venv
-source .venv/bin/activate
-
-# Install (or update) requirements
-python -m pip install -r requirements.txt
-
-python main.py
+uv run python main.py


### PR DESCRIPTION
## Summary
- Replace `requirements.txt` with `pyproject.toml` for dependency management
- Update `run.sh` and `run-celery.sh` to use `uv run` instead of manual venv/pip workflow
- Part of PY-2428 migration effort

## Test plan
- [ ] Run `./run-celery.sh` and verify the celery worker starts
- [ ] Run `./run.sh` and verify the app runs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)