### PR TITLE
build(test-celery-without-django): Migrate from pip to uv

### DIFF
--- a/test-celery-without-django/pyproject.toml
+++ b/test-celery-without-django/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "test-celery-without-django"
+version = "0"
+requires-python = ">=3.12"
+
+dependencies = [
+    "celery>=5.4.0",
+    "ipdb>=0.13.13",
+    "redis>=5.2.1",
+    "sentry-sdk[celery]",
+]
+
+[tool.uv.sources]
+sentry-sdk = { path = "../../sentry-python", editable = true }

--- a/test-celery-without-django/requirements.txt
+++ b/test-celery-without-django/requirements.txt
@@ -1,6 +1,0 @@
-celery
-redis
-
--e ../../../code/sentry-python 
-
-ipdb

--- a/test-celery-without-django/run-celery.sh
+++ b/test-celery-without-django/run-celery.sh
@@ -1,28 +1,15 @@
 #!/usr/bin/env bash
-
-# exit on first error
 set -euo pipefail
 
-# Delete Celery beat schedule because because when switching versions
-# a wrong schedule will cause strange errors
-rm -f celerybeat-schedule
+if ! command -v uv &> /dev/null; then
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
 
-# Delete redis database (empty the queue)
+rm -f celerybeat-schedule
 rm -rf dump.rdb
 
-# create and activate virtual environment
-python -m venv .venv
-source .venv/bin/activate
-
-# Install (or update) requirements
-pip install -r requirements.txt
-
-# Start redis server
 redis-server --daemonize yes
 
-# Run Celery and beat in the same process
-celery -A tasks.app worker \
+uv run celery -A tasks.app worker \
     --concurrency=1 \
     --max-tasks-per-child=1
-
-    # --loglevel=DEBUG \

--- a/test-celery-without-django/run.sh
+++ b/test-celery-without-django/run.sh
@@ -1,13 +1,8 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
-# exit on first error
-set -xe
+if ! command -v uv &> /dev/null; then
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
 
-# create and activate virtual environment
-python -m venv .venv
-source .venv/bin/activate
-
-# Install (or update) requirements
-python -m pip install -r requirements.txt
-
-python main.py
+uv run python main.py


### PR DESCRIPTION
## Summary
- Replace `requirements.txt` with `pyproject.toml` for dependency management
- Update `run.sh` and `run-celery.sh` to use `uv run` instead of manual venv/pip workflow
- Part of PY-2428 migration effort

## Test plan
- [ ] Run `./run-celery.sh` and verify the celery worker starts
- [ ] Run `./run.sh` and verify the app runs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)